### PR TITLE
exercise1: implemented exercise1

### DIFF
--- a/src/main/java/com/luxoft/springdb/lab1/dao/CountryDao.java
+++ b/src/main/java/com/luxoft/springdb/lab1/dao/CountryDao.java
@@ -32,7 +32,7 @@ public class CountryDao extends JdbcDaoSupport {
 
 	public List<Country> getCountryList() {
 		// TODO: implement it
-		JdbcTemplate jdbcTemplate = new JdbcTemplate();
+		JdbcTemplate jdbcTemplate = new JdbcTemplate(getDataSource());
 		return jdbcTemplate.query(GET_ALL_COUNTRIES_SQL, COUNTRY_ROW_MAPPER);
 	}
 
@@ -47,15 +47,9 @@ public class CountryDao extends JdbcDaoSupport {
 
 	public void updateCountryName(String codeName, String newCountryName) {
 		// TODO: implement it
-	}
-
-	public void loadCountries() {
-		for (String[] countryData : COUNTRY_INIT_DATA) {
-			String sql = LOAD_COUNTRIES_SQL + "('" + countryData[0] + "', '"
-					+ countryData[1] + "');";
-//			System.out.println(sql);
-			getJdbcTemplate().execute(sql);
-		}
+		JdbcTemplate jdbcTemplate = new JdbcTemplate(getDataSource());
+		jdbcTemplate.execute(UPDATE_COUNTRY_NAME_SQL_1 + newCountryName + "'" +
+								UPDATE_COUNTRY_NAME_SQL_2 + codeName + "'");
 	}
 
 	public Country getCountryByCodeName(String codeName) {

--- a/src/main/java/com/luxoft/springdb/lab1/dao/CountryRowMapper.java
+++ b/src/main/java/com/luxoft/springdb/lab1/dao/CountryRowMapper.java
@@ -16,6 +16,7 @@ public class CountryRowMapper implements RowMapper<Country> {
 		Country country = new Country();
 		country.setId(resultSet.getInt(ID));
 		country.setName(resultSet.getString(NAME));
+		country.setCodeName(resultSet.getString(CODE_NAME));
 
 		// TODO: implement it
 		

--- a/src/main/resources/application-context.xml
+++ b/src/main/resources/application-context.xml
@@ -8,7 +8,8 @@
 		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd">
 
 	<jdbc:embedded-database id="dataSource">
-		<jdbc:script location="classpath:db-schema.sql"/>	
+		<jdbc:script location="classpath:db-schema.sql"/>
+		<jdbc:script location="classpath:db-test-data.sql"/>
 	</jdbc:embedded-database>
 
     <bean id="countryDao" class="com.luxoft.springdb.lab1.dao.CountryDao">

--- a/src/main/resources/db-test-data.sql
+++ b/src/main/resources/db-test-data.sql
@@ -1,0 +1,12 @@
+INSERT INTO country(id, name, code_name) VALUES (1, 'Australia', 'AU');
+INSERT INTO country(id, name, code_name) VALUES (2, 'Canada', 'CA');
+INSERT INTO country(id, name, code_name) VALUES (3, 'France', 'FR');
+INSERT INTO country(id, name, code_name) VALUES (4, 'Hong Kong', 'HK');
+INSERT INTO country(id, name, code_name) VALUES (5, 'Iceland', 'IC');
+INSERT INTO country(id, name, code_name) VALUES (6, 'Japan', 'JP');
+INSERT INTO country(id, name, code_name) VALUES (7, 'Nepal', 'NP');
+INSERT INTO country(id, name, code_name) VALUES (8, 'Russian Federation', 'RU');
+INSERT INTO country(id, name, code_name) VALUES (9, 'Sweden', 'SE');
+INSERT INTO country(id, name, code_name) VALUES (10, 'Switzerland', 'CH');
+INSERT INTO country(id, name, code_name) VALUES (11, 'United Kingdom', 'GB');
+INSERT INTO country(id, name, code_name) VALUES (12, 'United States', 'US');

--- a/src/test/java/com/luxoft/springdb/lab1/JdbcTest.java
+++ b/src/test/java/com/luxoft/springdb/lab1/JdbcTest.java
@@ -30,7 +30,6 @@ public class JdbcTest{
     @Before
     public void setUp() throws Exception {
         initExpectedCountryLists();
-        countryDao.loadCountries();
     }
 
     
@@ -51,6 +50,7 @@ public class JdbcTest{
         List<Country> countryList = countryDao.getCountryListStartWith("A");
         assertNotNull(countryList);
         assertEquals(expectedCountryListStartsWithA.size(), countryList.size());
+        System.out.println(expectedCountryListStartsWithA.size());
         for (int i = 0; i < expectedCountryListStartsWithA.size(); i++) {
             assertEquals(expectedCountryListStartsWithA.get(i), countryList.get(i));
         }


### PR DESCRIPTION
Answers to questions and additional information about issues:

Part3
12.  
Using JdbcTemplate looks like
```
Object[] args = new Object[] {"x", "y"};
String sql = "select * from foo where a = ? and b = ?"; 
jdbcTemplate.query(sql, args, resultSetExtractor);
```

Using NamedParameterJdbcTemplate looks like
```
String sql = "select * from foo where a = :mya and b = :myb";
Map<String, Object> argMap = new HashMap<String, Object>();
argMap.put("mya", "x");
argMap.put("myb", "y");
namedParameterJdbcTemplate.query(sql, argMap, resultSetExtractor);
```

The idea is that matching the arguments by name is less error-prone than having to specify them in a particular order.

14. 
DirtiesContext annotation tells the testing framework to close and recreate the context for later tests.
Nothing changed after adding @DirtiesContext. It's Ok for methods testCountryList() and testCountryListStartsWithA() because they just read information and don't modify it.

Part4
18.  
An embedded database can be useful during the development phase of a project because of its lightweight nature. Benefits include ease of configuration, quick startup time, testability, and the ability to rapidly evolve your SQL during development.